### PR TITLE
chore: docker 환경 구축

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+.env
+.DS_Store

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .env
 .DS_Store
+.idea/**

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,0 +1,13 @@
+FROM openjdk:17-jdk-slim
+
+COPY . /app
+
+WORKDIR /app
+
+RUN chmod +x ./gradlew && \
+    sed -i 's/\r$//' gradlew && \
+    ./gradlew build
+
+EXPOSE 8080
+
+ENTRYPOINT java -jar ./build/libs/boongObbang-0.0.1-SNAPSHOT.jar

--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -17,6 +17,7 @@ repositories {
 
 dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter'
+	implementation 'org.springframework.boot:spring-boot-starter-web'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 }
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,65 @@
+version: '3'
+
+services:
+  redis:
+    image: redis:latest
+    container_name: redis
+    command: redis-server --port 6379
+    hostname: redis
+    labels:
+      - 'name=redis'
+      - 'mode=standalone'
+    ports:
+      - 6379:6379
+    networks:
+      - boong
+
+  mariadb:
+    container_name: mariadb
+    build: ./mariadb/
+    hostname: mariadb
+    #volumes:
+    #  - v_mariadb:/var/lib/mysql
+    env_file:
+      - .env
+    ports:
+      - 3300:3300 #3306을 써야하지만 충돌이 일어나므로 3300으로 사용
+    networks:
+      - boong
+
+  backend:
+    container_name: backend
+    build: ./backend/
+    hostname: backend
+    env_file:
+      - .env
+    ports:
+      - 8080:8080
+    networks:
+      - boong
+    depends_on:
+      - redis
+      - mariadb
+  
+  frontend:
+    container_name: frontend
+    build: ./frontend/
+    ports:
+      - 3000:3000
+    networks:
+      - boong
+
+networks:
+  boong:
+    driver: bridge
+
+#TODO: ec2에서는 볼륨 적용하기
+
+# volumes:
+#   v_mariadb:
+#     name: v_mariadb
+#     driver: local
+#     driver_opts:
+#       type: 'none'
+#       o: 'bind'
+#       device: '/Users'

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,0 +1,11 @@
+FROM node:18
+
+COPY . /app
+
+WORKDIR /app
+
+RUN npm install
+
+EXPOSE 3000
+
+ENTRYPOINT [ "npm", "start" ]

--- a/mariadb/Dockerfile
+++ b/mariadb/Dockerfile
@@ -1,0 +1,24 @@
+# FROM mariadb:latest
+
+FROM debian:bullseye
+
+RUN \
+    apt-get -y update && \
+    apt-get -y upgrade && \
+    apt-get -y install mariadb-server && \
+    apt-get -y install mariadb-client
+
+COPY db_start.sh .
+
+RUN apt-get update && apt-get install -y mariadb-client
+
+RUN { \
+        echo '[mysqld]'; \
+        echo 'character-set-server=utf8'; \
+        echo 'collation-server=utf8_general_ci'; \
+    } > /etc/mysql/conf.d/charset.cnf
+
+#3306을 써야하지만 충돌이 일어나므로 3300으로 사용
+EXPOSE 3300
+
+CMD [ "sh", "db_start.sh" ]

--- a/mariadb/db_start.sh
+++ b/mariadb/db_start.sh
@@ -1,0 +1,16 @@
+service mariadb start;
+
+cat /var/lib/mysql/.setup 2> /dev/null
+
+mysql -e "CREATE DATABASE IF NOT EXISTS $DB_NAME";
+mysql -e "CREATE USER IF NOT EXISTS '$DB_USER'@'%' IDENTIFIED BY '$DB_PASSWORD'";
+mysql -e "GRANT ALL PRIVILEGES ON $DB_NAME.* TO '$DB_USER'@'%'";
+mysql -e "FLUSH PRIVILEGES";
+mysql -e "ALTER USER '$DB_ROOT'@'localhost' IDENTIFIED BY '$DB_ROOT_PASSWORD'";
+
+mysql $DB_NAME -u$DB_ROOT -p$DB_ROOT_PASSWORD
+mysqladmin -u$DB_ROOT -p$DB_ROOT_PASSWORD shutdown
+
+touch /var/lib/mysql/.setup
+
+exec mysqld --console


### PR DESCRIPTION
## ✅ PR 유형
- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 코드 수정
- [ ] 기능에 영향을 주지 않는 변경사항
- [ ] 기능 향상
- [ ] 파일 or 폴더명 수정
- [ ] 파일 or 폴더 삭제


## 📝 PR 내용
<!---- 해당 PR에 어떤 작업을 하였는지 설명해주세요. ---->
- 도커 환경을 구축했습니다 (frontend, backend, mariadb, redis로 구성)
- env파일이 있어야 실행이 가능합니다
- env 파일을 통해 mariadb의 유저와 db를 생성했습니다
- host와의 충돌이 있어 mariadb의 포트를 3306이 아닌 3300으로 사용합니다
- 추후에 AWS EC2로 이관할 때 volums를 추가할 예정입니다

### 👻사용방법
컨테이너 실행: `docker-compose up -d`
컨테이너 중지 및 삭제: `docker-compose down`
이미지 삭제: `docker rmi -f $(docker images -q -a)`

**❗주의**
만일 컨테이너를 실행했고, mariadb의 유저가 생성이 되었는데 접근이 안된다???
host 컴퓨터에서 다음 명령어를 실행합니다 
1. `sudo lsof -i:3306`
2. `sudo kill -9 [PID]` 
