### PR TITLE
feat: 남의 메인페이지, 편지읽기 & 삭제 API 연결

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -67,6 +67,8 @@ services:
   frontend:
     build: ./frontend
     image: boongobbang/boongobbang-frontend:latest
+    env_file:
+      - .env
     environment:
       # - NODE_ENV=production
       - NODE_ENV=development

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -16,7 +16,7 @@ function App() {
             <Route path="/" element={<LoginPage />} index />
             <Route path="/login/oauth2/code/kakao" element={<KakaoRedirect />} />
             <Route path="/mainpage" element={<MainPage />} />
-            <Route path="/main" element={<NotMyMainPage />} />
+            <Route path="/main/:uuid" element={<NotMyMainPage />} />
             <Route path="/settings" element={<PreSettingPage />} />
           </Route>
         </Routes>

--- a/frontend/src/components/LoginPage/SocialKakao.jsx
+++ b/frontend/src/components/LoginPage/SocialKakao.jsx
@@ -1,7 +1,7 @@
 import kakaoSymbol from "/images/kakao_symbol.png"
 
 const SocialKakao = () => {
-  const Rest_api_key = ""; //REST API KEY
+  const Rest_api_key = import.meta.env.VITE_KAKAO_REST_API_KEY; //REST API KEY
   const redirect_uri = "http://localhost:5173/login/oauth2/code/kakao"; //Redirect URI
   // oauth 요청 URL
   const kakaoURL = `https://kauth.kakao.com/oauth/authorize?client_id=${Rest_api_key}&redirect_uri=${redirect_uri}&response_type=code`;

--- a/frontend/src/components/MainPage/DefaultScreen.jsx
+++ b/frontend/src/components/MainPage/DefaultScreen.jsx
@@ -31,7 +31,7 @@ const DefaultScreen = () => {
           light={getData.light}
         />
       </div>
-      <Display messages={getData.messages} />
+      <Display messages={getData.messages} dday={getData.d_day} />
       <Bottom dday={getData.d_day} />
     </div>
   );

--- a/frontend/src/components/MainPage/DefaultScreen.jsx
+++ b/frontend/src/components/MainPage/DefaultScreen.jsx
@@ -1,12 +1,13 @@
 import Top from "@components/MainPage/Top";
 import Display from "@components/MainPage/Display";
 import Bottom from "@components/MainPage/Bottom";
-import { loginState } from "@states//ModalState";
+import { loginState, lettersState } from "@states//ModalState";
 import { useRecoilState } from "recoil";
 import { useEffect, useState } from "react";
 
 const DefaultScreen = () => {
   const [login, setLogin] = useRecoilState(loginState);
+  const [lettersCount] = useRecoilState(lettersState);
   const [getData, setGetData] = useState({color: 0, d_day: 100, light:0, messages: [], name: ""});
 
   useEffect(() => {
@@ -20,7 +21,7 @@ const DefaultScreen = () => {
     .then(data => {
       setGetData(data.data)
     })
-  }, [])
+  }, [lettersCount])
 
   return (
     <div className="flex w-full h-full flex-col justify-center items-center min-[733px]:w-[733px] min-w-[375px]">

--- a/frontend/src/components/MainPage/Display.jsx
+++ b/frontend/src/components/MainPage/Display.jsx
@@ -4,7 +4,7 @@ import right from "/images/icon_right.png";
 import left from "/images/icon_left.png";
 import Letters from "@components/MainPage/Letters";
 
-const Display = ({ messages }) => {
+const Display = ({ messages, dday }) => {
   const [start, setStart] = useState(0);
   const [end, setEnd] = useState(9);
   const [currentPage, setCurrentPage] = useState(1);
@@ -18,7 +18,7 @@ const Display = ({ messages }) => {
   return (
     <div className="flex w-full">
       <div className="relative -mt-1 w-full">
-        <Letters messages={messages.slice(start, end)} />
+        <Letters messages={messages.slice(start, end)} dday={dday} />
         {totalPages > 1 && currentPage !== 1 ? (
           <img
             onClick={() => setCurrentPage(currentPage - 1)}

--- a/frontend/src/components/MainPage/Letter.jsx
+++ b/frontend/src/components/MainPage/Letter.jsx
@@ -4,14 +4,21 @@ import mint from "/images/letter_mint.png";
 import pizza from "/images/letter_pizza.png";
 import redbean from "/images/letter_redbean.png";
 import sweetpotato from "/images/letter_sweetpotato.png";
-import { useSetRecoilState } from 'recoil';
-import { modalReadLetterState } from '@states/ModalState';
+import { useRecoilValue, useSetRecoilState } from 'recoil';
+import { modalReadLetterState, loginState } from '@states/ModalState';
 
 const Letter = ({ letterLoc, tagLoc, message }) => {
   const colors = [redbean, cream, sweetpotato, pizza, choco, mint];
   const setModalOpen = useSetRecoilState(modalReadLetterState);
+  const login = useRecoilValue(loginState);
+
+  const checkLogin = () => {
+    if (login.isLoin)
+      setModalOpen(true)
+  }
+
   return (
-    <div onClick={() => setModalOpen(true)}>
+    <div onClick={() => checkLogin()}>
       <img
         className={`absolute ${letterLoc[0]} ${letterLoc[1]} w-[30%]`}
         src={colors[message.color]}

--- a/frontend/src/components/MainPage/Letter.jsx
+++ b/frontend/src/components/MainPage/Letter.jsx
@@ -4,21 +4,37 @@ import mint from "/images/letter_mint.png";
 import pizza from "/images/letter_pizza.png";
 import redbean from "/images/letter_redbean.png";
 import sweetpotato from "/images/letter_sweetpotato.png";
-import { useRecoilValue, useSetRecoilState } from 'recoil';
-import { modalReadLetterState, loginState } from '@states/ModalState';
+import { useRecoilValue, useSetRecoilState, useRecoilState } from 'recoil';
+import { modalReadLetterState, loginState, modalAlertState } from '@states/ModalState';
+import { useEffect } from 'react';
 
-const Letter = ({ letterLoc, tagLoc, message }) => {
+const Letter = ({ letterLoc, tagLoc, message, dday }) => {
   const colors = [redbean, cream, sweetpotato, pizza, choco, mint];
   const setModalOpen = useSetRecoilState(modalReadLetterState);
+  const [ alertOpen, setAlertOpen ] = useRecoilState(modalAlertState);
   const login = useRecoilValue(loginState);
 
-  const checkLogin = () => {
+  useEffect(() => {
+    if (alertOpen.isOpen) {
+        setTimeout(() => {
+            setAlertOpen({isOpen: false, message: ""});
+        }, 2000);
+    }
+  }, [alertOpen]);
+
+  const clickLetter = () => {
     if (login.isLogin)
-      setModalOpen(true)
+    {
+      if (dday > 0 )
+        setAlertOpen({isOpen: true, message: "12월 25일부터 편지를 읽을 수 있어요😢"});
+      else
+        setModalOpen({ isOpen: true, idx: message.idx })
+    }
+    
   }
 
   return (
-    <div onClick={() => checkLogin()}>
+    <div onClick={() => clickLetter()}>
       <img
         className={`absolute ${letterLoc[0]} ${letterLoc[1]} w-[30%]`}
         src={colors[message.color]}

--- a/frontend/src/components/MainPage/Letter.jsx
+++ b/frontend/src/components/MainPage/Letter.jsx
@@ -13,7 +13,7 @@ const Letter = ({ letterLoc, tagLoc, message }) => {
   const login = useRecoilValue(loginState);
 
   const checkLogin = () => {
-    if (login.isLoin)
+    if (login.isLogin)
       setModalOpen(true)
   }
 

--- a/frontend/src/components/MainPage/Letters.jsx
+++ b/frontend/src/components/MainPage/Letters.jsx
@@ -1,6 +1,6 @@
 import Letter from "@components/MainPage/Letter";
 
-const Letters = ({ messages }) => {
+const Letters = ({ messages, dday }) => {
   const letterLocation = [
     ["top-[55%]", "left-[5%]"],
     ["top-[55%]", "left-[35%]"],
@@ -36,6 +36,7 @@ const Letters = ({ messages }) => {
           letterLoc={letterLocation[locationIdx]}
           tagLoc={tagLocation[locationIdx]}
           message={message}
+          dday={dday}
         />
       );
     }

--- a/frontend/src/components/MainPage/readLetter/CloseButton.jsx
+++ b/frontend/src/components/MainPage/readLetter/CloseButton.jsx
@@ -7,7 +7,7 @@ const CloseButton = () => {
     
     return (
         <div className="flex justify-end">
-            <button className="w-[30px]" onClick={() => setModalOpen(false)}>
+            <button className="w-[30px]" onClick={() => setModalOpen({isOpen: false, idx: 0})}>
                 <img src={closeImage} alt="close button"/>
             </button>
         </div>

--- a/frontend/src/components/MainPage/readLetter/FinalCheckDelete.jsx
+++ b/frontend/src/components/MainPage/readLetter/FinalCheckDelete.jsx
@@ -1,17 +1,22 @@
 import icon_submit from "/images/icon_submit.png";
 import icon_close from "/images/icon_close.png";
 import { useEffect } from "react";
-import { useRecoilState, useSetRecoilState } from "recoil";
+import { useRecoilState, useRecoilValue, useSetRecoilState } from "recoil";
 import {
   modalReadLetterState,
   modalSubmitState,
   modalAlertState,
+  loginState,
+  lettersState
 } from "@states//ModalState";
 
 const FinalCheckDelete = () => {
   const [readOpen, setReadOpen] = useRecoilState(modalReadLetterState);
   const setDeleteOpen = useSetRecoilState(modalSubmitState);
   const [alertOpen, setAlertOpen] = useRecoilState(modalAlertState);
+  const login = useRecoilValue(loginState);
+  const selectedLetter = useRecoilValue(modalReadLetterState);
+  const [lettersCount, setLettersCount] = useRecoilState(lettersState);
 
   useEffect(() => {
     if (alertOpen.isOpen) {
@@ -22,11 +27,19 @@ const FinalCheckDelete = () => {
   }, [alertOpen]);
 
   const clickDelete = () => {
-    setDeleteOpen({ isOpen: false, isSubmit: false });
-    setReadOpen({ isOpen: false, idx: 0});
-    setAlertOpen({ isOpen: true, message: "삭제가 완료되었어요😉" });
-
-    //todo: api 호출
+    fetch(login.url + "/mainpage/message/" + selectedLetter.idx, {
+      method: "PATCH",
+      headers: {
+        Authorization: login.token
+      }
+    })
+    .then(res => res.json())
+    .then(data => {
+      setDeleteOpen({ isOpen: false, isSubmit: false });
+      setReadOpen({ isOpen: false, idx: 0});
+      setAlertOpen({ isOpen: true, message: "삭제가 완료되었어요😉" });
+      setLettersCount({count: lettersCount.count - 1});
+    })
   };
 
   return (

--- a/frontend/src/components/MainPage/readLetter/FinalCheckDelete.jsx
+++ b/frontend/src/components/MainPage/readLetter/FinalCheckDelete.jsx
@@ -23,7 +23,7 @@ const FinalCheckDelete = () => {
 
   const clickDelete = () => {
     setDeleteOpen({ isOpen: false, isSubmit: false });
-    setReadOpen(false);
+    setReadOpen({ isOpen: false, idx: 0});
     setAlertOpen({ isOpen: true, message: "삭제가 완료되었어요😉" });
 
     //todo: api 호출

--- a/frontend/src/components/MainPage/readLetter/LetterPop.jsx
+++ b/frontend/src/components/MainPage/readLetter/LetterPop.jsx
@@ -1,16 +1,39 @@
 import LetterPopButtons from "@components/MainPage/readLetter/LetterPopButtons";
 import LetterPopLabel from "@components/MainPage/readLetter/LetterPopLabel";
 import LetterPopTextArea from "@components/MainPage/readLetter/LetterPopTextArea";
+import { useEffect, useState } from "react";
+import { useRecoilValue } from "recoil";
+import { loginState, modalReadLetterState } from "@states//ModalState";
 
 const LetterPop = () => {
+  const login = useRecoilValue(loginState);
+  const selectedLetter = useRecoilValue(modalReadLetterState);
+  const [getData, setGetData] = useState({to: "", message: "", made_by: ""});
+
+  console.log(selectedLetter.idx);
+  useEffect(() => {
+    fetch(login.url + "/mainpage/message/" + selectedLetter.idx, {
+      method: "GET",
+      headers: {
+        Authorization: login.token
+      },
+    })
+    .then(res => res.json())
+    .then(data => {
+      console.log(data);
+      if (data.status === 200)
+        setGetData(data.data);
+    })
+  }, [])
+
   return (
     <div className="w-full h-[100%] text-[20px] font-bold p-[6%]">
       <LetterPopButtons />
-      <LetterPopLabel label={"To"} text={"aaa"} />
+      <LetterPopLabel label={"To"} text={getData.to} />
       <div className="h-[60%]">
-        <LetterPopTextArea text={"hello"} />
+        <LetterPopTextArea text={getData.message} />
       </div>
-      <LetterPopLabel label={"Made by"} text={"aaa"} />
+      <LetterPopLabel label={"Made by"} text={getData.made_by} />
     </div>
   );
 };

--- a/frontend/src/components/MainPage/readLetter/LetterPop.jsx
+++ b/frontend/src/components/MainPage/readLetter/LetterPop.jsx
@@ -10,7 +10,6 @@ const LetterPop = () => {
   const selectedLetter = useRecoilValue(modalReadLetterState);
   const [getData, setGetData] = useState({to: "", message: "", made_by: ""});
 
-  console.log(selectedLetter.idx);
   useEffect(() => {
     fetch(login.url + "/mainpage/message/" + selectedLetter.idx, {
       method: "GET",

--- a/frontend/src/components/NotMyMainPage/MakeLetter/FinalCheckSubmit.jsx
+++ b/frontend/src/components/NotMyMainPage/MakeLetter/FinalCheckSubmit.jsx
@@ -1,12 +1,14 @@
 import icon_submit from "/images/icon_submit.png";
 import icon_close from "/images/icon_close.png";
 import { useEffect } from "react";
+import { useParams } from "react-router-dom";
 import { useRecoilState, useSetRecoilState } from "recoil";
 import {
   modalLetterState,
   writeLetterState,
   modalSubmitState,
   modalAlertState,
+  loginState
 } from "@states//ModalState";
 
 const FinalCheckSubmit = () => {
@@ -14,6 +16,8 @@ const FinalCheckSubmit = () => {
   const [writeLetter, setWriteLetter] = useRecoilState(writeLetterState);
   const setSubmitOpen = useSetRecoilState(modalSubmitState);
   const [alertOpen, setAlertOpen] = useRecoilState(modalAlertState);
+  const [login, setLogin] = useRecoilState(loginState);
+  const { uuid } = useParams();
 
   useEffect(() => {
     if (alertOpen.isOpen) {
@@ -24,12 +28,25 @@ const FinalCheckSubmit = () => {
   }, [alertOpen]);
 
   const clickSubmit = () => {
-    setSubmitOpen({ isOpen: false, isSubmit: true });
-    setLetterOpen({ isOpen: false, page: 1 });
-    setAlertOpen({ isOpen: true, message: "편지가 등록되었어요😉" });
-
-    //todo: api 호출
-    setWriteLetter({ color: 0, to: "", message: "", from: "" });
+    fetch(login.url + "/main/" + uuid, {
+      method: "POST",
+      headers: {
+        'Content-Type': 'application/json'
+      },
+      body: JSON.stringify({
+        to: writeLetter.to,
+        message: writeLetter.message,
+        made_by: writeLetter.made_by,
+        color: writeLetter.color,
+     }),
+    })
+    .then(res => res.json())
+    .then(data => {
+      setSubmitOpen({ isOpen: false, isSubmit: true });
+      setLetterOpen({ isOpen: false, page: 1 });
+      setAlertOpen({ isOpen: true, message: "편지가 등록되었어요😉" });
+      setWriteLetter({ color: 0, to: "", message: "", from: "" });
+    })
   };
 
   return (

--- a/frontend/src/components/NotMyMainPage/MakeLetter/FinalCheckSubmit.jsx
+++ b/frontend/src/components/NotMyMainPage/MakeLetter/FinalCheckSubmit.jsx
@@ -8,7 +8,8 @@ import {
   writeLetterState,
   modalSubmitState,
   modalAlertState,
-  loginState
+  loginState,
+  lettersState
 } from "@states//ModalState";
 
 const FinalCheckSubmit = () => {
@@ -17,6 +18,7 @@ const FinalCheckSubmit = () => {
   const setSubmitOpen = useSetRecoilState(modalSubmitState);
   const [alertOpen, setAlertOpen] = useRecoilState(modalAlertState);
   const [login, setLogin] = useRecoilState(loginState);
+  const [lettersCount, setLettersCount] = useRecoilState(lettersState);
   const { uuid } = useParams();
 
   useEffect(() => {
@@ -46,6 +48,7 @@ const FinalCheckSubmit = () => {
       setLetterOpen({ isOpen: false, page: 1 });
       setAlertOpen({ isOpen: true, message: "편지가 등록되었어요😉" });
       setWriteLetter({ color: 0, to: "", message: "", from: "" });
+      setLettersCount({count: lettersCount.count + 1});
     })
   };
 

--- a/frontend/src/components/NotMyMainPage/MakeLetter/TopOfChooseBOB.jsx
+++ b/frontend/src/components/NotMyMainPage/MakeLetter/TopOfChooseBOB.jsx
@@ -9,7 +9,7 @@ const Top = () => {
 
   const closeMakeLetter = () => {
     setLetterOpen({ isOpen: false, page: 1 });
-    setWriteLetter({ color: 0, to: "", message: "", from: "" });
+    setWriteLetter({ color: 0, to: "", message: "", made_by: "" });
   };
 
   return (

--- a/frontend/src/components/NotMyMainPage/MakeLetter/TopOfWriteLetter.jsx
+++ b/frontend/src/components/NotMyMainPage/MakeLetter/TopOfWriteLetter.jsx
@@ -26,7 +26,7 @@ const Top = () => {
 
   const closeMakeLetter = () => {
     setLetterOpen({ isOpen: false, page: 1 });
-    setWriteLetter({ color: 0, to: "", message: "", from: "" });
+    setWriteLetter({ color: 0, to: "", message: "", made_by: "" });
   };
 
   const clickSubmit = () => {
@@ -38,7 +38,7 @@ const Top = () => {
       setAlertOpen({ isOpen: true, message: "편지의 내용을 입력해주세요😉" });
       return;
     }
-    if (writeLetter.from === "") {
+    if (writeLetter.made_by === "") {
       setAlertOpen({ isOpen: true, message: "Made by를 입력해주세요😉" });
       return;
     }

--- a/frontend/src/components/NotMyMainPage/MakeLetter/WriteLetter.jsx
+++ b/frontend/src/components/NotMyMainPage/MakeLetter/WriteLetter.jsx
@@ -36,7 +36,7 @@ const WriteLetter = () => {
             setAlertOpen({isOpen: true, message: "10자 까지 작성할 수 있어요😢"});
             return;
         }
-        setWriteLetter({...writeLetter, from: e.target.value});
+        setWriteLetter({...writeLetter, made_by: e.target.value});
     }
 
     return (
@@ -59,12 +59,12 @@ const WriteLetter = () => {
                 value={writeLetter.message}
             />
             <div className="flex justify-between mt-4">
-                <div className="w-1/3 flex justify-center items-center text-lg min-[400px]:text-[17px] min-[500px]:text-[20px] min-[600px]:text-[24px]">From</div>
+                <div className="w-1/3 flex justify-center items-center text-lg min-[400px]:text-[17px] min-[500px]:text-[20px] min-[600px]:text-[24px]">Made by</div>
                 <input 
                     type="text"
                     className="h-8  w-3/4 border-l-[25px] border-[#DDDCDC] bg-[#DDDCDC] rounded-lg focus:outline-0 min-[500px]:h-[2rem] min-[600px]:h-[2.5rem] min-[700px]:h-[3rem]"
                     onChange={onChangeFrom}
-                    value={writeLetter.from}
+                    value={writeLetter.made_by}
                 />
             </div>
         </div>

--- a/frontend/src/components/layout.jsx
+++ b/frontend/src/components/layout.jsx
@@ -73,7 +73,7 @@ const Layout = () => {
 
   const closeMakeLetter = () => {
     setLetterOpen({ isOpen: false, page: 1 });
-    setWriteLetter({ color: 0, to: "", message: "", from: "" });
+    setWriteLetter({ color: 0, to: "", message: "", made_by: "" });
   };
 
   return (

--- a/frontend/src/components/layout.jsx
+++ b/frontend/src/components/layout.jsx
@@ -109,8 +109,8 @@ const Layout = () => {
       {/* 편지 읽기 */}
       <Modal
         style={letterStyled}
-        isOpen={readOpen}
-        onRequestClose={() => setReadOpen(false)}
+        isOpen={readOpen.isOpen}
+        onRequestClose={() => setReadOpen({ isOpen: false, idx: 0 })}
         ariaHideApp={false}
       >
         <LetterPop />

--- a/frontend/src/pages/NotMyMainPage.jsx
+++ b/frontend/src/pages/NotMyMainPage.jsx
@@ -8,7 +8,7 @@ import { useRecoilState } from "recoil";
 
 const NotMyMainPage = () => {
   const { uuid } = useParams();
-  const [login, setLogin] = useRecoilState(loginState);
+  const [login] = useRecoilState(loginState);
   const [getData, setGetData] = useState({color: 0, d_day: 100, light:0, messages: [], name: ""});
   const [lettersCount] = useRecoilState(lettersState);
 
@@ -20,7 +20,6 @@ const NotMyMainPage = () => {
     .then(data => {
       setGetData(data.data);
     })
-    .catch(err => {console.log(err)})
   }, [lettersCount])
   
   return (

--- a/frontend/src/pages/NotMyMainPage.jsx
+++ b/frontend/src/pages/NotMyMainPage.jsx
@@ -3,13 +3,14 @@ import Display from "@components/MainPage/Display";
 import Bottom from "@components/NotMyMainPage/Bottom";
 import { useParams } from "react-router-dom";
 import { useEffect, useState } from "react";
-import { loginState } from "@states//ModalState";
+import { loginState, lettersState } from "@states//ModalState";
 import { useRecoilState } from "recoil";
 
 const NotMyMainPage = () => {
   const { uuid } = useParams();
   const [login, setLogin] = useRecoilState(loginState);
   const [getData, setGetData] = useState({color: 0, d_day: 100, light:0, messages: [], name: ""});
+  const [lettersCount] = useRecoilState(lettersState);
 
   useEffect(() => {
     fetch(login.url + "/main/" + uuid, {
@@ -20,7 +21,7 @@ const NotMyMainPage = () => {
       setGetData(data.data);
     })
     .catch(err => {console.log(err)})
-  }, [])
+  }, [lettersCount])
   
   return (
     <div className="flex w-screen h-screen justify-center">

--- a/frontend/src/pages/NotMyMainPage.jsx
+++ b/frontend/src/pages/NotMyMainPage.jsx
@@ -32,7 +32,7 @@ const NotMyMainPage = () => {
             light={getData.light}
             />
         </div>
-          <Display messages={getData.messages} />
+          <Display messages={getData.messages} dday={getData.d_day} />
           <Bottom dday={getData.d_day} />
       </div>
     </div>

--- a/frontend/src/pages/NotMyMainPage.jsx
+++ b/frontend/src/pages/NotMyMainPage.jsx
@@ -1,25 +1,39 @@
 import Top from "@components/MainPage/Top";
 import Display from "@components/MainPage/Display";
 import Bottom from "@components/NotMyMainPage/Bottom";
-import fakeData from "@components/MainPage/fake_api_data.json";
-import Title from "@components/MainPage/Title";
+import { useParams } from "react-router-dom";
+import { useEffect, useState } from "react";
+import { loginState } from "@states//ModalState";
+import { useRecoilState } from "recoil";
 
 const NotMyMainPage = () => {
-  if (fakeData.status === 200) console.log("api 연동 성공");
-  else console.log("api 연동 실패");
+  const { uuid } = useParams();
+  const [login, setLogin] = useRecoilState(loginState);
+  const [getData, setGetData] = useState({color: 0, d_day: 100, light:0, messages: [], name: ""});
+
+  useEffect(() => {
+    fetch(login.url + "/main/" + uuid, {
+      method: "GET",
+    })
+    .then(res => res.json())
+    .then(data => {
+      setGetData(data.data);
+    })
+    .catch(err => {console.log(err)})
+  }, [])
 
   return (
     <div className="flex w-screen h-screen justify-center">
       <div className="flex w-full h-full flex-col justify-center items-center min-[733px]:w-[733px] min-w-[375px]">
         <div className="flex h-2/5 w-full ">
           <Top
-            title={fakeData.data.name}
-            roof={fakeData.data.roof}
-            light={fakeData.data.light}
+            title={getData.name}
+            roof={getData.color}
+            light={getData.light}
             />
         </div>
-          <Display messages={fakeData.data.messages} />
-          <Bottom dday={fakeData.data["d-day"]} />
+          <Display messages={getData.messages} />
+          <Bottom dday={getData.d_day} />
       </div>
     </div>
   );

--- a/frontend/src/pages/NotMyMainPage.jsx
+++ b/frontend/src/pages/NotMyMainPage.jsx
@@ -21,7 +21,7 @@ const NotMyMainPage = () => {
     })
     .catch(err => {console.log(err)})
   }, [])
-
+  
   return (
     <div className="flex w-screen h-screen justify-center">
       <div className="flex w-full h-full flex-col justify-center items-center min-[733px]:w-[733px] min-w-[375px]">

--- a/frontend/src/states/ModalState.js
+++ b/frontend/src/states/ModalState.js
@@ -19,7 +19,7 @@ const writeLetterState = atom({
     color: 0,
     to: "",
     message: "",
-    from: "",
+    made_by: "",
   }, // default value (aka initial value)
 });
 

--- a/frontend/src/states/ModalState.js
+++ b/frontend/src/states/ModalState.js
@@ -67,6 +67,13 @@ const loginState = atom({
   },
 });
 
+const lettersState = atom({
+  key: "lettersState",
+  default: {
+    count: 0,
+  }
+});
+
 export {
   modalHelperState,
   modalLetterState,
@@ -77,4 +84,5 @@ export {
   cartState,
   modalLoginHelperState,
   loginState,
+  lettersState,
 };

--- a/frontend/src/states/ModalState.js
+++ b/frontend/src/states/ModalState.js
@@ -33,7 +33,10 @@ const modalSubmitState = atom({
 
 const modalReadLetterState = atom({
   key: "modalReadLetterState",
-  default: false,
+  default: {
+    isOpen: false,
+    idx: 0,
+  }
 });
 
 const modalLoginHelperState = atom({


### PR DESCRIPTION
## ✅ PR 유형
- [x] 새로운 기능 추가
- [ ] 버그 수정
- [x] 코드 수정
- [ ] 기능에 영향을 주지 않는 변경사항
- [ ] 기능 향상
- [ ] 파일 or 폴더명 수정
- [ ] 파일 or 폴더 삭제


## 📝 PR 내용
남의 메인페이지 조회와 편지 쓰기, 나의 메인페이지 편지 읽기와 편지 삭제 API를 연결하였으며,
남의 메인페이지에서 붕어빵 클릭 시 반응 없도록(편지 읽지 못하도록) 적용하였고,
나의 메인페이지에서 붕어빵 클릭 시, d-day 이전일 경우 안내 팝업만 띄우도록 적용하였습니다.

